### PR TITLE
don't fail if git-symbolic-ref fails

### DIFF
--- a/add_asset_number_to_commit_message/prepare-commit-msg
+++ b/add_asset_number_to_commit_message/prepare-commit-msg
@@ -18,15 +18,15 @@ const _parse = lines => ({
 })
 const parse = content => _parse(content.split('\n'))
 
-const assetFormat = /[a-zA-Z]{1,3}-\d{5,}/
+const oidTokenFormat = /[a-zA-Z]{1,3}-\d{5,}/
 const matchText = match => match ? match[ 0 ] : ''
-const assetForBranch = symbolicRef => matchText(
-	assetFormat.exec(symbolicRef)
+const extractOidToken = branchName => matchText(
+	oidTokenFormat.exec(branchName)
 )
 
-async function tryGetAssetFromCurrentBranch() {
-	const symbolicRef = await tryGetCurrentBranchName()
-	return assetForBranch(symbolicRef)
+async function getOidToken() {
+	const branchName = await tryGetCurrentBranchName()
+	return extractOidToken(branchName)
 }
 
 async function tryGetCurrentBranchName() {
@@ -62,19 +62,19 @@ async function getMessageAndComments(messageFilename) {
 
 const references = (message, asset) => message.indexOf(asset) >= 0
 
-const formatMessage = (asset, message, comments) => `[${asset}] ${message.trim()}\n\n${comments.trim()}`
+const formatMessage = (token, message, comments) => `[${token}] ${message.trim()}\n\n${comments.trim()}`
 
 async function main(messageFilename) {
 	const [
-		asset,
+		token,
 		{ message, comments },
 	] = await Promise.all([
-		tryGetAssetFromCurrentBranch(),
+		getOidToken(),
 		getMessageAndComments(messageFilename),
 	])
 
-	if (asset && !references(message, asset)) {
-		const newMessage = formatMessage(asset, message, comments)
+	if (token && !references(message, token)) {
+		const newMessage = formatMessage(token, message, comments)
 		await writeFile(messageFilename, newMessage, { encoding: 'utf8' })
 	}
 }

--- a/add_asset_number_to_commit_message/prepare-commit-msg
+++ b/add_asset_number_to_commit_message/prepare-commit-msg
@@ -24,21 +24,34 @@ const assetForBranch = symbolicRef => matchText(
 	assetFormat.exec(symbolicRef)
 )
 
+async function tryGetAssetFromCurrentBranch() {
+	try {
+		const { stdout: symbolicRef } = await execPromise('git symbolic-ref HEAD')
+		return assetForBranch(symbolicRef)
+	}
+	catch (e) {
+		// git symbolic-ref might fail, don't hold up the commit
+		return ''
+	}
+}
+
+async function getMessageAndComments(messageFilename) {
+	const originalMessage = await readFile(messageFilename, { encoding: 'utf8' })
+	return parse(originalMessage)
+}
+
 const references = (message, asset) =>message.indexOf(asset) >= 0
 
 const formatMessage = (asset, message, comments) => `[${asset}] ${message.trim()}\n\n${comments.trim()}`
 
 async function main(messageFilename) {
 	const [
-		{ stdout: symbolicRef },
-		originalMessage,
+		asset,
+		{ message, comments },
 	] = await Promise.all([
-		execPromise('git symbolic-ref HEAD'),
-		readFile(messageFilename, { encoding: 'utf8' }),
+		tryGetAssetFromCurrentBranch(),
+		getMessageAndComments(messageFilename),
 	])
-
-	const asset = assetForBranch(symbolicRef)
-	const { message, comments } = parse(originalMessage)
 
 	if (asset && !references(message, asset)) {
 		const newMessage = formatMessage(asset, message, comments)

--- a/add_asset_number_to_commit_message/prepare-commit-msg
+++ b/add_asset_number_to_commit_message/prepare-commit-msg
@@ -25,14 +25,34 @@ const assetForBranch = symbolicRef => matchText(
 )
 
 async function tryGetAssetFromCurrentBranch() {
+	const symbolicRef = await tryGetCurrentBranchName()
+	return assetForBranch(symbolicRef)
+}
+
+async function tryGetCurrentBranchName() {
 	try {
 		const { stdout: symbolicRef } = await execPromise('git symbolic-ref HEAD')
-		return assetForBranch(symbolicRef)
+		return symbolicRef
 	}
 	catch (e) {
 		// git symbolic-ref might fail, don't hold up the commit
-		return ''
 	}
+
+	try {
+		const { stdout: branchList } = await execPromise('git branch --list --no-color')
+		const asterisk = branchList.indexOf('*')
+		if (asterisk >= 0) {
+			let newline = branchList.indexOf('\n', asterisk + 1)
+			if (newline < 0)
+				newline = branchList.length
+			return branchList.slice(asterisk + 1, newline)
+		}
+	}
+	catch (e) {
+		// don't hold up the commit
+	}
+
+	return ''
 }
 
 async function getMessageAndComments(messageFilename) {
@@ -40,7 +60,7 @@ async function getMessageAndComments(messageFilename) {
 	return parse(originalMessage)
 }
 
-const references = (message, asset) =>message.indexOf(asset) >= 0
+const references = (message, asset) => message.indexOf(asset) >= 0
 
 const formatMessage = (asset, message, comments) => `[${asset}] ${message.trim()}\n\n${comments.trim()}`
 


### PR DESCRIPTION
try/catch around `git symbolic-ref HEAD`, because it can fail sometimes.

Also, better parallelism!